### PR TITLE
LongvinterUpdate.sh relative file path

### DIFF
--- a/LongvinterUpdate.sh
+++ b/LongvinterUpdate.sh
@@ -9,11 +9,11 @@ UpdateServer () {
         git pull "https://github.com/Uuvana-Studios/longvinter-linux-server.git" main
         sleep 1
         echo "Starting server..."
-        sudo chmod -R ugo+rwx /home/steam/longvinter-linux-server/
+        sudo chmod -R ugo+rwx ~/longvinter-linux-server/
         sudo systemctl start longvinter && echo "Server is now running!"
 }
 
-cd /home/steam/longvinter-linux-server
+cd ~/longvinter-linux-server
 
 git fetch
 


### PR DESCRIPTION
my server is installed on a mounted drive 
my installation path : /mnt/raid5/home/steam/longvinter-linux-server/
so every time i run the script it's giving me errors due to wrong file path and not working properly.
so this is a little fix for people who installed longvinter in a different path or using another account to run the server.
it could be a good idea to do the same with LongvinterBackup.sh